### PR TITLE
Remove segfault

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.o
+/config.h
+/config.mk
+/oldrunner

--- a/bricks.c
+++ b/bricks.c
@@ -1,4 +1,6 @@
 /*  $Id: bricks.c,v 1.1.1.1 2010/07/17 17:30:32 culot Exp $  */
+/* vim: et ai sts=2 ts=2 sw=2:
+ * */
 
 /*
  * Copyright (c) 2010 Frederic Culot <frederic@culot.org>
@@ -65,7 +67,7 @@ bricks_free (void)
   while (!SLIST_EMPTY (&bricks))
     {
       struct brick *b;
-      
+
       b = SLIST_FIRST (&bricks);
       SLIST_REMOVE_HEAD (&bricks, bricksp);
       xfree (b);
@@ -118,7 +120,7 @@ void
 bricks_draw (void)
 {
   struct brick *b;
-  
+
   SLIST_FOREACH (b, &bricks, bricksp)
     draw_brick (&b->pos, b->state);
 }
@@ -127,13 +129,13 @@ unsigned
 bricks_broken_at (const struct coord *pos)
 {
   struct brick *b;
-  
+
   SLIST_FOREACH (b, &bricks, bricksp)
     {
       if (b->state == BRICK_BROKEN && coord_equal (&b->pos, pos))
         return 1;
     }
-  
+
   return 0;
 }
 

--- a/cfg.h
+++ b/cfg.h
@@ -1,4 +1,6 @@
 /*  $Id: cfg.h,v 1.1.1.1 2010/07/17 17:30:32 culot Exp $  */
+/* vim: et ai sts=2 ts=2 sw=2:
+ * */
 
 /*
  * Copyright (c) 2010 Frederic Culot <frederic@culot.org>

--- a/compat.h
+++ b/compat.h
@@ -1,4 +1,6 @@
 /*  $Id: compat.h,v 1.1.1.1 2010/07/17 17:30:32 culot Exp $  */
+/* vim: et ai sts=2 ts=2 sw=2:
+ * */
 
 /*
  * Copyright (c) 2010 Frederic Culot <frederic@culot.org>

--- a/coord.c
+++ b/coord.c
@@ -1,4 +1,6 @@
 /*  $Id: coord.c,v 1.1.1.1 2010/07/17 17:30:32 culot Exp $  */
+/* vim: et ai sts=2 ts=2 sw=2:
+ * */
 
 /*
  * Copyright (c) 2010 Frederic Culot <frederic@culot.org>
@@ -81,9 +83,9 @@ coord_compute (const struct coord *orig, enum move move, struct coord *dest)
       dest->y--;
       break;
     case MOV_DOWN:
-    case MOV_FALL:      
+    case MOV_FALL:
       dest->y++;
-      break;      
+      break;
     case MOV_LEFT:
       dest->x--;
       break;

--- a/foes.c
+++ b/foes.c
@@ -1,4 +1,6 @@
 /*  $Id: foes.c,v 1.1.1.1 2010/07/17 17:30:32 culot Exp $  */
+/* vim: et ai sts=2 ts=2 sw=2:
+ * */
 
 /*
  * Copyright (c) 2010 Frederic Culot <frederic@culot.org>
@@ -57,7 +59,7 @@ foes_free (void)
   while (!SLIST_EMPTY (&foes))
     {
       struct foe *f;
-      
+
       f = SLIST_FIRST (&foes);
       SLIST_REMOVE_HEAD (&foes, foesp);
       xfree (f);
@@ -166,14 +168,14 @@ compute_move (const struct coord *hero, struct foe *foe)
   struct coord dpos;
 
   if (foe->current_move == MOV_FALL)
-    coord_compute (&foe->pos, foe->current_move, &foe->pos);    
+    coord_compute (&foe->pos, foe->current_move, &foe->pos);
   else
     {
       coord_diff (hero, &foe->pos, &dpos);
       if (dpos.y != 0)
         {
           enum move wanted_dir, prefered_move;
-          
+
           if (foe->current_move != MOV_LEFT && foe->current_move != MOV_RIGHT)
             prefered_move = dpos.x >= 0 ? MOV_RIGHT : MOV_LEFT;
           else
@@ -203,7 +205,7 @@ static void
 try_escape (struct foe *f)
 {
   struct coord posorig;
-  
+
   if (!timer_delay_elapsed (&f->timer, FOES_ESCAPE_DELAY))
     return;
 
@@ -217,9 +219,9 @@ static void
 update_foe_pos (const struct coord *hero_pos, struct foe *f)
 {
   struct coord posorig;
-  
+
   coord_set_yx (&posorig, f->pos.y, f->pos.x);
-  compute_move (hero_pos, f);  
+  compute_move (hero_pos, f);
   if (!coord_equal (&posorig, &f->pos)
       && lvl_valid_move (&posorig, f->current_move, &f->pos, SP_FOE)
       && !another_foe_at_pos (f, &f->pos))
@@ -255,7 +257,7 @@ foes_update_pos (void)
   timer_get_time (&now);
   if (timer_diff (&now, &foes_timer) < FOES_DELAY)
     return;
-  
+
   hero_get_pos (&hero_pos);
 
   SLIST_FOREACH (foe, &foes, foesp)
@@ -263,7 +265,7 @@ foes_update_pos (void)
       struct coord foe_prevpos;
 
       coord_set_yx (&foe_prevpos, foe->pos.y, foe->pos.x);
-      
+
       if (foe->state & STATE_TRAPPED)
         try_escape (foe);
       else
@@ -285,6 +287,6 @@ foes_wallup_at (const struct coord *pos)
           return 1;
         }
     }
-  
+
   return 0;
 }

--- a/game.c
+++ b/game.c
@@ -1,4 +1,6 @@
 /*  $Id: game.c,v 1.1.1.1 2010/07/17 17:30:32 culot Exp $  */
+/* vim: et ai sts=2 ts=2 sw=2:
+ * */
 
 /*
  * Copyright (c) 2010 Frederic Culot <frederic@culot.org>
@@ -51,7 +53,7 @@ static void
 game_lost (void)
 {
   struct usr_input input;
-  
+
   gfx_game_over ();
   gfx_get_input (&input);
   game_end ();
@@ -61,7 +63,7 @@ void
 game_won (void)
 {
   struct usr_input input;
-  
+
   gfx_game_won ();
   gfx_get_input (&input);
   game_end ();
@@ -75,7 +77,7 @@ game_init (int startlvl)
     EXIT ("Could not load game levels. Aborting...");
   ginfo.lives = LIVES_AT_START;
   ginfo.level = startlvl + 1;
-  gfx_init ();  
+  gfx_init ();
   lvl_load (startlvl);
   hero_init ();
   game_update ();
@@ -92,12 +94,12 @@ set_view (void)
 
   lvl.w = lvl_width ();
   lvl.h = lvl_height ();
-  
+
   if (AUTO_CENTER_MODE || lvl.h > VIEWPORT_HEIGHT || lvl.w > VIEWPORT_WIDTH)
     {
       struct coord player_pos;
 
-      hero_get_pos (&player_pos);      
+      hero_get_pos (&player_pos);
       gfx_center_at (&player_pos);
     }
   else
@@ -135,7 +137,7 @@ read_level_row (char *row, unsigned rownum)
 {
   char *rowend;
   int len;
-  
+
   if (*row != '[')
     return 0;
   row++;
@@ -144,7 +146,7 @@ read_level_row (char *row, unsigned rownum)
     return 0;
   *rowend = '\0';
   len = rowend - row;
-  
+
   return lvl_set_row (rownum, len, row);
 }
 
@@ -201,7 +203,7 @@ game_load (const char *path)
   FILE *f;
   char *buf;
   unsigned rownum, newlevel;
-  
+
   if (!(f = io_fopen (LEVELS)))
     return 0;
 
@@ -219,12 +221,12 @@ game_load (const char *path)
             rownum = 0;                         \
           }                                     \
     } while (0)
-      
+
       /* Remove trailing spaces. */
       p = buf;
       while (isblank ((int)(*p)))
         p++;
-      
+
       switch (*p)
         {
         case '[':
@@ -244,8 +246,8 @@ game_load (const char *path)
           read_level_attr (p);
           break;
         }
-      
-#undef CHK_NEW_LVL      
+
+#undef CHK_NEW_LVL
     }
 
   io_fclose (f);
@@ -276,14 +278,14 @@ game_level_inc (void)
 void
 game_level_dec (void)
 {
-  ginfo.state |= LEVEL_CHANGE;  
+  ginfo.state |= LEVEL_CHANGE;
   ginfo.level--;
 }
 
 void
 game_lives_inc (void)
 {
-  ginfo.state |= LIVES_CHANGE;  
+  ginfo.state |= LIVES_CHANGE;
   ginfo.lives++;
 }
 

--- a/gfx.c
+++ b/gfx.c
@@ -1,4 +1,6 @@
 /*  $Id: gfx.c,v 1.2 2012/01/31 14:53:07 culot Exp $  */
+/* vim: et ai sts=2 ts=2 sw=2:
+ * */
 
 /*
  * Copyright (c) 2010 Frederic Culot <frederic@culot.org>
@@ -125,7 +127,7 @@ static void
 newpopup (struct window *pop)
 {
   const int BORDERWIDTH = 2;
-  
+
   pop->siz.w = scr.view.siz.w - 2 * BORDERWIDTH;
   pop->siz.h = scr.view.siz.h - 2 * BORDERWIDTH;
   pop->pos.y = scr.view.pos.y + BORDERWIDTH;
@@ -298,7 +300,7 @@ void
 gfx_game_over (void)
 {
   const char *rip =
-  "                   +-+                   \n" 
+  "                   +-+                   \n"
   "                  +-+-+-+                 \n"
   "                  +-+-+-+                 \n"
   "                    | |                   \n"

--- a/hero.c
+++ b/hero.c
@@ -1,4 +1,6 @@
 /*  $Id: hero.c,v 1.1.1.1 2010/07/17 17:30:32 culot Exp $  */
+/* vim: et ai sts=2 ts=2 sw=2:
+ * */
 
 /*
  * Copyright (c) 2010 Frederic Culot <frederic@culot.org>
@@ -117,10 +119,10 @@ hero_move (enum move move)
   /* First check if the move is valid with regards to current player state. */
   if (hero.state & STATE_DIGGING)
     return;
-    
+
   if ((hero.state & STATE_FALLING) && (move != MOV_FALL))
     move = MOV_FALL;
-  
+
   /* Then check if the move is valid with regards to the level layout. */
   hero_get_pos (&orig);
   if (!lvl_valid_move (&orig, move, &dest, SP_HERO))
@@ -131,10 +133,10 @@ hero_move (enum move move)
     }
   else
     hero_set_pos (&dest);
-  
+
   if (move == MOV_FALL || lvl_nothing_below (&hero.pos))
     hero.state |= STATE_FALLING;
-  
+
   gfx_move_sprite (SP_HERO, &orig, &hero.pos);
   check_collisions (&hero.pos);
 }
@@ -183,6 +185,6 @@ hero_wallup_at (const struct coord *pos)
       hero_die ();
       return 1;
     }
-  
+
   return 0;
 }

--- a/io.c
+++ b/io.c
@@ -1,4 +1,6 @@
 /*  $Id: io.c,v 1.1.1.1 2010/07/17 17:30:32 culot Exp $  */
+/* vim: et ai sts=2 ts=2 sw=2:
+ * */
 
 /*
  * Copyright (c) 2010 Frederic Culot <frederic@culot.org>
@@ -40,14 +42,14 @@ FILE *
 io_fopen (const char *path)
 {
   FILE *f;
-  
+
   if (!(f = fopen (path, "r")))
     {
       ERROR_MSG ("Could not open game file \"%s\": %s",
                  path, strerror (errno));
       return 0;
     }
-  
+
   return f;
 }
 

--- a/lvl.c
+++ b/lvl.c
@@ -1,4 +1,6 @@
 /*  $Id: lvl.c,v 1.3 2012/01/31 14:36:29 culot Exp $  */
+/* vim: et ai sts=2 ts=2 sw=2:
+ * */
 
 /*
  * Copyright (c) 2010, 2012 Frederic Culot <frederic@culot.org>
@@ -35,7 +37,7 @@
 #include "oldrunner.h"
 
 struct lvlattr {
-  struct size    siz;  
+  struct size    siz;
   char          *name;
   char          *author;
 };
@@ -52,27 +54,27 @@ struct level {
 static struct level    *curlvl;
 
 static enum sprite char2sprite[256] = {
-  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-  
-/*   !  "     #          $     %    &     '  (  )  *  +  ,     -     .  / */  
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+
+/*   !  "     #          $     %    &     '  (  )  *  +  ,     -     .  / */
   0, 0, 0, SP_BRICK, SP_MONEY, 0, SP_FOE, 0, 0, 0, 0, 0, 0, SP_ROPE, 0, 0,
-  
-/*0  1  2  3  4  5  6  7  8  9  :  ;  <  =  >  ? */  
+
+/*0  1  2  3  4  5  6  7  8  9  :  ;  <  =  >  ? */
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-  
-/*   @     A  B  C  D  E  F  G      H      I  J  K  L  M  N  O */  
+
+/*   @     A  B  C  D  E  F  G      H      I  J  K  L  M  N  O */
   SP_HERO, 0, 0, 0, 0, 0, 0, 0, SP_LADDER, 0, 0, 0, 0, 0, 0, 0,
-  
-/*P  Q  R  S  T  U        V        W      X      Y  Z  [  \  ]  ^  _ */  
+
+/*P  Q  R  S  T  U        V        W      X      Y  Z  [  \  ]  ^  _ */
   0, 0, 0, 0, 0, 0, SP_FAKE_BRICK, 0, SP_CIMENT, 0, 0, 0, 0, 0, 0, 0,
-  
-/*`  a  b  c  d  e  f  g  h  i  j  k  l  m  n  o */  
+
+/*`  a  b  c  d  e  f  g  h  i  j  k  l  m  n  o */
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-  
-/*p  q  r  s  t  u  v  w  x  y  z  {          |         }  ~    */  
+
+/*p  q  r  s  t  u  v  w  x  y  z  {          |         }  ~    */
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, SP_ESCAPE_LADDER, 0, 0, 0,
-  
+
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -120,7 +122,7 @@ static void
 init_layout (struct level *l)
 {
   int i;
-  
+
   l->lay = xcalloc (l->attr.siz.h, sizeof (char *));
   for (i = 0; i < l->attr.siz.h; i++)
     l->lay[i] = xmalloc (l->attr.siz.w);
@@ -174,7 +176,7 @@ lvl_set_size (char *sizstr)
   if (!(y = strchr (sizstr, 'x')))
     return 0;
   *y++ = '\0';
-  
+
   sizex = strtonum (x, 0, LEVEL_MAX_WIDTH, &errstr);
   if (errstr)
     return 0;
@@ -205,9 +207,9 @@ lvl_set_row (int rownum, int rowlen, const char *row)
     }
   if (!curlvl->lay)
     init_layout (curlvl);
-  
+
   memcpy (curlvl->lay[rownum], row, rowlen);
-  
+
   return 1;
 }
 
@@ -237,7 +239,7 @@ lvl_add_new (void)
 
   return 1;
 }
-             
+
 void
 lvl_init (void)
 {
@@ -262,7 +264,7 @@ lvl_load_dynaobjs (void)
   int r, c;
 
   dynaobj_free ();
-    
+
   for (r = 0; r < curlvl->attr.siz.h; r++)
     {
       lvlpos.y = r;
@@ -311,7 +313,7 @@ draw_static_objects (void)
       for (c = 0; c < curlvl->attr.siz.w; c++)
         {
           enum sprite sp;
-          
+
           pos.x = c;
           sp = sprite_at_pos (&pos);
           gfx_show_sprite (obj_is_static[sp] ? sp : SP_NONE, &pos);
@@ -354,7 +356,7 @@ load_level (void)
   lvl_load_dynaobjs ();
   lvl_update_new ();
   hero_init ();
-  show_level_info ();  
+  show_level_info ();
 }
 
 static void
@@ -364,7 +366,7 @@ lvl_select_current (int lvlnum)
   while (lvlnum)
     {
       curlvl = TAILQ_NEXT (curlvl, levelsp);
-      EXIT_IF (curlvl == 0, "lvl_select_current: invalid level number");      
+      EXIT_IF (curlvl == 0, "lvl_select_current: invalid level number");
       lvlnum--;
     }
 }
@@ -375,7 +377,7 @@ lvl_load (int levelnum)
 {
   lvl_select_current (levelnum);
   load_level ();
-  
+
   return 1;
 }
 
@@ -384,9 +386,9 @@ lvl_load_next (void)
 {
   if (!(curlvl = TAILQ_NEXT (curlvl, levelsp)))
     game_won ();
-  game_level_inc ();  
+  game_level_inc ();
   load_level ();
-  
+
   return 1;
 }
 
@@ -394,14 +396,14 @@ unsigned
 lvl_load_prev (void)
 {
   struct level *previous_lvl;
-  
+
   if (!(previous_lvl = TAILQ_PREV (curlvl, levels_head, levelsp)))
     return 0;
 
   curlvl = previous_lvl;
-  game_level_dec ();  
+  game_level_dec ();
   load_level ();
-  
+
   return 1;
 }
 
@@ -449,7 +451,7 @@ valid_decor_move (const struct coord *pos_orig, const struct coord *pos_dest,
 
   if (pos_dest->y < 0 && sp_orig == SP_ESCAPE_LADDER)
     return 1;
-  
+
   sp_dest = lvl_decor_at_pos (pos_dest);
   switch (sp_dest)
     {
@@ -462,19 +464,19 @@ valid_decor_move (const struct coord *pos_orig, const struct coord *pos_dest,
 
     case SP_BRICK:
       return wanted_move != MOV_UP && bricks_broken_at (pos_dest) ? 1 : 0;
-      
+
     case SP_CIMENT:
       return 0;
-      
+
     case SP_LADDER:
       return wanted_move == MOV_FALL ? 0 : 1;
-      
+
     case SP_ESCAPE_LADDER:
       if (sp == SP_HERO)
         return wanted_move == MOV_FALL ? 0 : 1;
       else
         return wanted_move == MOV_UP ? 0 : 1;
-      
+
     default:
       return 0;
       /* NOTREACHED */
@@ -492,7 +494,7 @@ lvl_valid_move (const struct coord *orig, enum move wanted_move,
   if (dest->y >= (int)curlvl->attr.siz.h
       || dest->x < 0 || dest->x >= curlvl->attr.siz.w)
     return 0;
-  
+
   return valid_decor_move (orig, dest, wanted_move, sp);
 }
 
@@ -521,7 +523,7 @@ unsigned
 lvl_obstacle_at (const struct coord *pos)
 {
   enum sprite sp;
-  
+
   if (pos->y < 0 || pos->x < 0
       || pos->y > curlvl->attr.siz.h || pos->x > curlvl->attr.siz.w)
     return 1;
@@ -535,7 +537,7 @@ lvl_objects_update (void)
 {
   bricks_update ();
   bricks_draw ();
-  money_draw ();  
+  money_draw ();
   foes_update_pos ();
 }
 
@@ -571,7 +573,7 @@ got_way (const struct coord *orig,
                     pos.y + (wanted_dir == MOV_UP ? -1 : 1), pos.x);
       if (valid_decor_move (&pos, &wanted_pos, wanted_dir, SP_NONE))
         return 1;
-      
+
       pos.x += prefered_move == MOV_RIGHT ? 1 : -1;
     }
 
@@ -583,7 +585,7 @@ lvl_shortest_way (const struct coord *orig,
                   enum move wanted_dir, enum move prefered_move)
 {
   struct coord dest;
-  
+
   if (lvl_valid_move (orig, wanted_dir, &dest, SP_NONE))
     return wanted_dir;
   else

--- a/mem.c
+++ b/mem.c
@@ -1,4 +1,6 @@
 /*  $Id: mem.c,v 1.1.1.1 2010/07/17 17:30:32 culot Exp $  */
+/* vim: et ai sts=2 ts=2 sw=2:
+ * */
 
 /*
  * Copyright (c) 2010 Frederic Culot <frederic@culot.org>
@@ -40,7 +42,7 @@ void *
 xmalloc (size_t size)
 {
   void *p;
-  
+
   EXIT_IF (size == 0, "xmalloc: zero size");
   p = malloc (size);
   EXIT_IF (p == 0, "xmalloc: out of memory");

--- a/money.c
+++ b/money.c
@@ -1,4 +1,6 @@
 /*  $Id: money.c,v 1.1.1.1 2010/07/17 17:30:32 culot Exp $  */
+/* vim: et ai sts=2 ts=2 sw=2:
+ * */
 
 /*
  * Copyright (c) 2010 Frederic Culot <frederic@culot.org>
@@ -51,7 +53,7 @@ money_free (void)
   while (!SLIST_EMPTY (&money_list))
     {
       struct money *m;
-      
+
       m = SLIST_FIRST (&money_list);
       SLIST_REMOVE_HEAD (&money_list, moneyp);
       xfree (m);
@@ -72,7 +74,7 @@ void
 money_draw (void)
 {
   struct money  *m;
-  
+
   SLIST_FOREACH (m, &money_list, moneyp)
     gfx_show_sprite (SP_MONEY, &m->pos);
 }
@@ -81,7 +83,7 @@ void
 money_check_at (const struct coord *hero_pos)
 {
   struct money *m;
-  
+
   SLIST_FOREACH (m, &money_list, moneyp)
     {
       if (coord_equal (&m->pos, hero_pos))

--- a/oldrunner.c
+++ b/oldrunner.c
@@ -1,4 +1,6 @@
 /*  $Id: oldrunner.c,v 1.1.1.1 2010/07/17 17:30:32 culot Exp $  */
+/* vim: et ai sts=2 ts=2 sw=2:
+ * */
 
 /*
  * Copyright (c) 2010 Frederic Culot <frederic@culot.org>
@@ -81,6 +83,6 @@ main (int argc, char **argv)
   game_init (startlvl);
   usr_input ();
   game_end ();
-  
+
   return 0;
 }

--- a/oldrunner.h
+++ b/oldrunner.h
@@ -1,4 +1,6 @@
 /*  $Id: oldrunner.h,v 1.2 2012/01/06 10:11:30 culot Exp $  */
+/* vim: et ai sts=2 ts=2 sw=2:
+ * */
 
 /*
  * Copyright (c) 2010, 2012 Frederic Culot <frederic@culot.org>
@@ -70,10 +72,10 @@ enum sprite {
   SP_LADDER,
   SP_ROPE,
   SP_ESCAPE_LADDER,
-  
+
   /* Sprites used for objects. */
   SP_MONEY,
-  
+
   /* Sprites used to draw characters. */
   SP_HERO,
   SP_FOE,
@@ -92,7 +94,7 @@ enum move {
 };
 
 struct size {
-  unsigned  h; /* height */  
+  unsigned  h; /* height */
   unsigned  w; /* width */
 };
 
@@ -112,13 +114,13 @@ struct usr_input {
 };
 
 struct game_info {
-#define  NO_CHANGE     0x0  
+#define  NO_CHANGE     0x0
 #define  LEVEL_CHANGE  0x1
 #define  SCORE_CHANGE  0x2
-#define  LIVES_CHANGE  0x4  
+#define  LIVES_CHANGE  0x4
   int       state;
-  
-  unsigned  level;  
+
+  unsigned  level;
   unsigned  score;
   unsigned  lives;
 };

--- a/timer.c
+++ b/timer.c
@@ -1,4 +1,6 @@
 /*  $Id: timer.c,v 1.1.1.1 2010/07/17 17:30:32 culot Exp $  */
+/* vim: et ai sts=2 ts=2 sw=2:
+ * */
 
 /*
  * Copyright (c) 2010 Frederic Culot <frederic@culot.org>

--- a/usr.c
+++ b/usr.c
@@ -1,4 +1,6 @@
 /*  $Id: usr.c,v 1.1.1.1 2010/07/17 17:30:32 culot Exp $  */
+/* vim: et ai sts=2 ts=2 sw=2:
+ * */
 
 /*
  * Copyright (c) 2010 Frederic Culot <frederic@culot.org>
@@ -87,7 +89,7 @@ usr_input (void)
         case ORKEY_DIG_RIGHT:
           hero_dig (MOV_RIGHT);
           break;
-          
+
         case ORKEY_LEVEL_NEXT:
           lvl_load_next ();
           break;
@@ -98,7 +100,7 @@ usr_input (void)
         case ORKEY_SUICIDE:
           hero_die ();
           break;
-          
+
         default:
           /*
            * No action were performed by the user in the time interval.


### PR DESCRIPTION
When trying oldrunner in Alpine with Docker inside a tmux session... it was constantly crashing. It seems that setting `TERM=screen` triggered the error actually.

Fact is that `update_foe_pos()` is called inside a loop iterating over `foes` in `foes_update_pos()`, but it might reset the whole list of foes by calling `hero_die()`. This means that the iteration in `foes_update_pos()` is no longer valid and has to be stopped (the list of foes is deleted and re-created when calling `hero_die()`).

I took the liberty of setting the right vim modeline to help preserve the same structure as the rest of the code. I also took the liberty to remove trailing white spaces left around.